### PR TITLE
prevent ExceptionWriter.get_terminal_width from being able to return 0

### DIFF
--- a/pretty_errors/__init__.py
+++ b/pretty_errors/__init__.py
@@ -393,9 +393,17 @@ class ExceptionWriter():
     def get_terminal_width(self):
         """Width of terminal in characters."""
         try:
-            return os.get_terminal_size()[0]
+            default = int(os.environ['COLUMNS'])
+            assert default != 0
+        except (ValueError, KeyError, AssertionError):
+            default = 79
+
+        try:
+            rv = os.get_terminal_size()[0]
+            assert rv != 0
+            return rv
         except Exception:
-            return 79
+            return default
 
 
     def get_line_length(self):


### PR DESCRIPTION
In some environments, os.get_terminal_size()[0] can be 0. This makes no sense
and causes errors later on. This change:
    1. prevents get_terminal_width from passing on 0 to the rest of the program
    2. attempts to get the environment variable COLUMNS instead, and makes sure
    it is valid.
If both of these fail, the default value of 79 is set.

The priority is:
  1. os.get_terminal_size()[0] (old behaviour)
  2. if 1. fails or returns 0, environment variable COLUMNS
  3. if 2. returns 0 or an invalid string, return default value of 79. (original behaviour)

The specific error that got me to investigate was on line 435 (in the commit) when ExceptionWriter.output_text calls ExceptionWriter.get_line_length which calls ExceptionWriter.get_terminal_width. The output is used as a modulo, and the modulo 0 error is raised.