### PR TITLE
Fix arguments to str.join method in getsitepackages()

### DIFF
--- a/pretty_errors/__main__.py
+++ b/pretty_errors/__main__.py
@@ -40,8 +40,8 @@ else:
     if in_virtualenv:
         def getsitepackages():
             sep = "\\\\" if os.path.sep == "\\" else os.path.sep
-            pattern1 = re.compile(r'^%s$' % sep.join(os.environ['VIRTUAL_ENV'], 'lib', 'python[0-9.]+', 'site-packages'))
-            pattern2 = re.compile(r'^%s$' % sep.join(os.environ['VIRTUAL_ENV'], 'lib', 'site-packages'))
+            pattern1 = re.compile(r'^%s$' % sep.join([os.environ['VIRTUAL_ENV'], 'lib', 'python[0-9.]+', 'site-packages']))
+            pattern2 = re.compile(r'^%s$' % sep.join([os.environ['VIRTUAL_ENV'], 'lib', 'site-packages']))
             paths = [path for path in set(sys.path) if pattern1.search(path) or pattern2.search(path)]
             return paths
 


### PR DESCRIPTION
str.join only takes a single iterable as an argument. 
fixes "TypeError: str.join() takes exactly one argument (4 given)"
When running pretty_errors 1.2.22 in a virtualenv

